### PR TITLE
Updates to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ Add to your `urls.py`:
    
    urlpatterns = [
       url(r'^admin/sqlapp/(?:sql/)?$', execute_sql, name='sql'),
+      url(r'^admin/', include(admin.site.urls), name='admin'),
    ]
 ```
+**Note:** The `sqlapp` URL pattern must come BEFORE the `admin` pattern as shown above.
 
 ##### Contributors
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A simple app for executing SQL queries in Django admin panel.
 Add to your `INSTALLED_APPS` in `settings.py`:
 
 
-```
+```python
     INSTALLED_APPS = [
       ...
       'sqlapp',
@@ -38,8 +38,12 @@ Add to your `INSTALLED_APPS` in `settings.py`:
 Add to your `urls.py`:
 
 
-```
-    url(r'^admin/sqlapp/(?:sql/)?$', execute_sql, name='sql'),
+```python
+   from sqlapp.sqlapp import execute_sql
+   
+   urlpatterns = [
+      url(r'^admin/sqlapp/(?:sql/)?$', execute_sql, name='sql'),
+   ]
 ```
 
 ##### Contributors


### PR DESCRIPTION
Need a few tweaks to the README because a step is missing (the import statement for `execute_sql`) and a note needs to be added that the `sqlapp` URL pattern needs to come before the standard `admin` pattern.